### PR TITLE
Replace Droid Arabic Naskh with Vazirmtn

### DIFF
--- a/src/partials/head.html.eco
+++ b/src/partials/head.html.eco
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%- @site.title %><%- (@document.title && (' | ' + @document.title)) || '' %></title>
-  <%- @getBlock("styles").add(["//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css", "/style/bootstrap-rtl.css","http://fonts.googleapis.com/earlyaccess/droidarabicnaskh.css","/style/style.css"]).toHTML() %>
+  <%- @getBlock("styles").add(["//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css", "/style/bootstrap-rtl.css","https://fonts.googleapis.com/css?family=Vazirmatn","/style/style.css"]).toHTML() %>
 
   <% @getBlock("styles").add(["./style/bootstrap.css", "./style/bootstrap-rtl.css","./style/style.css"]).toHTML() %>
 

--- a/src/render/style/style.css
+++ b/src/render/style/style.css
@@ -12,11 +12,11 @@ img {
 }
 
 body {
-	font-family: 'Droid Arabic Naskh', serif;
+	font-family: 'Vazirmatn', serif;
 }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
-	font-family: 'Droid Arabic Naskh', serif;
+	font-family: 'Vazirmatn', serif;
 }
 
 .footer {


### PR DESCRIPTION
حالا که فونت وزیر به گوگل فونت [اضافه شده ](https://fonts.google.com/specimen/Vazirmatn?query=vazir)بهتر دیدم که از این فونت به جای فونت نسخ استفاده بشه که خوانایی کتاب هم بالاتر بره. 
هرچند پروژه `docpad` مدت زیادی هستش که نگهداری نمیشه و به نظرم ارزشش رو داره که کل ریپو به یه استکیک جنرتیور دیگه مثل [mkdocs](https://github.com/mkdocs/mkdocs) بازنویسی بشه. 
 پروژه با نسخه آخر Nodejs بیلد نمیشه و آخرین ورژن docpad هم با پلاگین ها هماهنگی نداره و باید به نسخه `~6.82.5` داونگرید کرد 

ممنونم از وقت و تلاشی که برای ترجمه این کتاب گذاشتی. 

یادی هم کنیم از مرحوم صابر راستی کردار به خاطر تلاش هایی که برای فونت فارسی متن باز انجام داد. 